### PR TITLE
Add a button that when turned will wait for destiny to go live and switch to his stream

### DIFF
--- a/DGG Injector/DGG Injector Chrome/main.js
+++ b/DGG Injector/DGG Injector Chrome/main.js
@@ -67,7 +67,7 @@ const switchToDestiny = (timer) => setInterval(() => {
 	}
 }, timer);
 
-const isDestinyOnline = () => document.querySelector('[href="/mrmouton"] .side-nav-card__live-status span').textContent !== "Offline";
+const isDestinyOnline = () => document.querySelector('[href="/destiny"] .side-nav-card__live-status span').textContent !== "Offline";
 
 //message handler
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/DGG Injector/DGG Injector Chrome/main.js
+++ b/DGG Injector/DGG Injector Chrome/main.js
@@ -62,8 +62,9 @@ let cont_evt = setInterval(() => {
 const switchToDestiny = (timer) => setInterval(() => {
 	if(location.pathname === "/destiny") clearInterval(this);
 	else if (isDestinyOnline()) {
-		window.location = "/destiny"
-		chrome.storage.sync.set({"--dgg--WaitForDestiny": false});
+		chrome.storage.sync.set({"--dgg--WaitForDestiny": false}, () => {
+			window.location = "/destiny";
+		});	
 	}
 }, timer);
 

--- a/DGG Injector/DGG Injector Chrome/main.js
+++ b/DGG Injector/DGG Injector Chrome/main.js
@@ -67,7 +67,10 @@ const switchToDestiny = (timer) => setInterval(() => {
 	}
 }, timer);
 
-const isDestinyOnline = () => document.querySelector('[href="/destiny"] .side-nav-card__live-status span').textContent !== "Offline";
+const isDestinyOnline = () => {
+	const statusElementContent = document.querySelector('[href="/destiny"] .side-nav-card__live-status span')
+	return statusElementContent && statusElementContent.textContent.toLowerCase() !== "offline" 
+}
 
 //message handler
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -387,6 +390,7 @@ function addAutoDestinyLiveButton() {
 		const waitForDestiny = data["--dgg--WaitForDestiny"];
 		const fillColor = waitForDestiny ? "red" : "white";
 		destinyLiveButton.querySelector('svg').style.fill = fillColor;
+		if(waitForDestiny) destinyLiveButton.timeOutScript = switchToDestiny(500);
 	})
 
 	destinyLiveButton.onclick = () => {

--- a/DGG Injector/DGG Injector Chrome/main.js
+++ b/DGG Injector/DGG Injector Chrome/main.js
@@ -50,6 +50,7 @@ let cont_evt = setInterval(() => {
 		if(found){
 			addDGG(width);
 			addEvents();
+			setTwitchVideoFullScreen();
 			//if it is enabled, show dgg, otherwise default to twitch
 			if(enable) toggleDGG("dgg");
 			else toggleDGG("twitch");
@@ -215,6 +216,14 @@ function addDGG(width){
 		dom.parentNode.innerHTML += resizer + swapper + dgg;
 		//add the event handler DOM (takes up whole screen)
 	}
+}
+
+function setTwitchVideoFullScreen() {
+	const player = document.querySelector('.channel-root__player--with-chat');
+	const info = document.querySelector('.channel-root__info--with-chat');
+
+	if(player) player.classList.remove("channel-root__player--with-chat");
+	if(info) info.classList.remove("channel-root__info--with-chat");
 }
 
 function removeDGG(){

--- a/DGG Injector/DGG Injector Chrome/main.js
+++ b/DGG Injector/DGG Injector Chrome/main.js
@@ -4,7 +4,7 @@ const DEFAULT_WIDTH = "300px";
 
 //this interval gets the current whitelist and saves it locally
 let datagetter = setInterval(() => {
-	const head = getTwitch();
+	let head = getTwitch();
 
 	if(head.isTwitch){
 		chrome.storage.sync.get(["--dgg--Whitelist"], (data) => {
@@ -74,7 +74,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 		//toggle dgg based on if it is enabled or not on the current channel
 		//event will trigger when you click the extension icon
 		if(request.message === "--dgg--toggle"){
-			console.log("KYLETEST", "THIS IS ON");
 			
 			let dgg = findDGG();
 			let head = getTwitch();
@@ -137,7 +136,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 				window.location.reload();
 			}
 		}
-		
 });
 
 function updateIFrames(channel){


### PR DESCRIPTION
Added a button to the nav bar that when turned on will look for Destiny to get online and switch over to his stream when he does.  This is defaulted to off and if you turn it on it will turn itself back off once the switch has been made.

It will be a white "D" button when off and red "D" button when on.

If you aren't interested in adding this functionality to your extension, no worries.  I mostly wrote it for myself.